### PR TITLE
Update 2b-privileged-esri.yaml

### DIFF
--- a/SecurityContextConstraints/RedHatOpenShift/2b-privileged-esri.yaml
+++ b/SecurityContextConstraints/RedHatOpenShift/2b-privileged-esri.yaml
@@ -50,6 +50,6 @@ volumes:
   - secret
 allowHostPID: false
 allowHostNetwork: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 apiVersion: security.openshift.io/v1
 allowedCapabilities:


### PR DESCRIPTION
Running a pod (post-admission via the SCC) with privileged set to true also requires that allowPrivilegeEscalation is true.