### PR TITLE
Clarify that ArcGIS Enterprise on Kubernetes does not support secrets managers

### DIFF
--- a/Guides/amazon-eks-deployment-guide.md
+++ b/Guides/amazon-eks-deployment-guide.md
@@ -237,6 +237,8 @@ Deploy ArcGIS Enterprise on Kubernetes
 ### 1. Populate deploy.properties file
 Follow instructions from [Run the deployment script in silent mode](https://enterprise-k8s.arcgis.com/en/latest/deploy/run-the-deployment-script.htm#ESRI_SECTION1_930D8184D9E9480BB679ABED1743A8CE) in _Run the deployment script_.
 
+Note: ArcGIS Enterprise uses application-level encryption and stores secrets as Kubernetes secrets. It does not have the functionality to integrate with secrets managers such as AWS Secrets Manager.
+
 <details>
 <summary>Example deploy.properties file contents:</summary>
 <br>

--- a/Guides/azure-kubernetes-service-deployment-guide.md
+++ b/Guides/azure-kubernetes-service-deployment-guide.md
@@ -144,6 +144,8 @@ Deploy ArcGIS Enterprise on Kubernetes
 ### 1. Populate deploy.properties file
 Follow instructions from [Run the deployment script in silent mode](https://enterprise-k8s.arcgis.com/en/latest/deploy/run-the-deployment-script.htm#ESRI_SECTION1_930D8184D9E9480BB679ABED1743A8CE) in _Run the deployment script_.
 
+Note: ArcGIS Enterprise uses application-level encryption and stores secrets as Kubernetes secrets. It does not have the functionality to integrate with secrets managers such as Azure Key Vault.
+
 <details>
 <summary>Example deploy.properties file contents:</summary>
 <br>

--- a/Guides/google-kubernetes-engine-deployment-guide.md
+++ b/Guides/google-kubernetes-engine-deployment-guide.md
@@ -123,6 +123,8 @@ Deploy ArcGIS Enterprise on Kubernetes
 ### 1. Populate deploy.properties file
 Follow instructions from [Run the deployment script in silent mode](https://enterprise-k8s.arcgis.com/en/latest/deploy/run-the-deployment-script.htm#ESRI_SECTION1_930D8184D9E9480BB679ABED1743A8CE) in _Run the deployment script_.
 
+Note: ArcGIS Enterprise uses application-level encryption and stores secrets as Kubernetes secrets. It does not have the functionality to integrate with secrets managers such as Google Secret Manager.
+
 <details>
 <summary>Example deploy.properties file contents:</summary>
 <br>


### PR DESCRIPTION
Adds statement with corresponding example to each deployment guide.